### PR TITLE
Consider duplicate history items

### DIFF
--- a/fussy-test.el
+++ b/fussy-test.el
@@ -511,6 +511,19 @@ Test that it matches the output of `orderless-filter'+`orderless-flex'."
                          (orderless-pattern-compiler "41234asdfbasdf..adf")))
     (fussy-pattern-str (fussy-pattern-flex-rx "41234asdfbasdf..adf")))))
 
+;;
+;; (@* "`fussy--history-hash-table'" )
+;;
+
+(ert-deftest fussy--history-hash-table-test ()
+  "Test `fussy--history-hash-table'."
+  (setf fussy-history-variable '("first" "second" "first"))
+  (let ((minibuffer-history-variable 'fussy-history-variable))
+    (let ((hist (fussy--history-hash-table)))
+      (should (eq (gethash "first" hist) 0))
+      (should (eq (gethash "second" hist) 1)))))
+
+
 (defun fussy-pattern-str (pattern-compiled)
   "Return PATTERN-COMPILED as a string.
 

--- a/fussy.el
+++ b/fussy.el
@@ -745,6 +745,7 @@ Key is the history string and Value is the history position."
                                       :size (length hist))))
     (cl-loop for index from 0
              for item in hist
+             unless (gethash item table)
              do (puthash item index table))
     table))
 


### PR DESCRIPTION
Fixed an issue where the first index found was not used if there were duplicate items in the history.

User can avoid this issue by setting `history-delete-duplicates`, but I think it's better to fix it.
