### PR TITLE
fix(flx-rs): remove bad chars from STR when using flx-rs

### DIFF
--- a/README.org
+++ b/README.org
@@ -83,7 +83,7 @@ lisp implementation.
      :fetcher github
      :files (:defaults "bin"))
     :config
-    (setq fussy-score-fn 'flx-rs-score)
+    (setq fussy-score-fn 'fussy-flx-rs-score)
     (flx-rs-load-dyn))
 #+end_src
 
@@ -548,7 +548,7 @@ a different algorithm.
      :fetcher github
      :files (:defaults "bin"))
     :config
-    (setq fussy-score-fn 'flx-rs-score)
+    (setq fussy-score-fn 'fussy-flx-rs-score)
     (flx-rs-load-dyn))
 
   (use-package fussy
@@ -556,7 +556,7 @@ a different algorithm.
     :straight
     (fussy :type git :host github :repo "jojojames/fussy")
     :config
-    (setq fussy-score-fn 'flx-rs-score)
+    (setq fussy-score-fn 'fussy-flx-rs-score)
     (setq fussy-filter-fn 'fussy-filter-orderless-flex)
 
     (push 'fussy completion-styles)

--- a/fussy.el
+++ b/fussy.el
@@ -290,7 +290,7 @@ FN should at least take in STR and QUERY."
           (const :tag "Score using Flx"
                  ,'flx-score)
           (const :tag "Score using Flx-RS"
-                 ,'flx-rs-score)
+                 ,#'fussy-flx-rs-score)
           (const :tag "Score using Fuz"
                  ,#'fussy-fuz-score)
           (const :tag "Score using Fuz-Bin"
@@ -1117,6 +1117,10 @@ result: LIST ^a"
 (declare-function "fuz-calc-score-skim" "fuz")
 (declare-function "fuz-fuzzy-match-clangd" "fuz")
 (declare-function "fuz-calc-score-clangd" "fuz")
+
+(defun fussy-flx-rs-score (str query &rest args)
+  "Score STR for QUERY with ARGS using `flx-rs-score'."
+  (flx-rs-score (funcall fussy-remove-bad-char-fn str) query args))
 
 (defun fussy-fuz-score (str query &rest _args)
   "Score STR for QUERY using `fuz'.


### PR DESCRIPTION
When using the `flx-rs` scoring backend, we need to run given string values through `fussy-remove-bad-char-fn` to match the behavior of using the flx scoring backend.

Without cleaning up bad characters, `flx-rs` seems like it works, but a lot of result candidates do not appear, yielding a much smaller result set compared to using `flx`. This fixes that, so results for both match.