### PR TITLE
fix(flx-rs): avoid errors when flx-rs package is not installed

### DIFF
--- a/fussy.el
+++ b/fussy.el
@@ -1120,7 +1120,9 @@ result: LIST ^a"
 
 (defun fussy-flx-rs-score (str query &rest args)
   "Score STR for QUERY with ARGS using `flx-rs-score'."
-  (flx-rs-score (funcall fussy-remove-bad-char-fn str) query args))
+  (require 'flx-rs)
+  (when (fboundp 'flx-rs-score)
+    (flx-rs-score (funcall fussy-remove-bad-char-fn str) query args)))
 
 (defun fussy-fuz-score (str query &rest _args)
   "Score STR for QUERY using `fuz'.


### PR DESCRIPTION
This is based on how the other wrapper score functions work, by requiring the relevant package, and wrapping the call in a `fboundp` check.

Issue was introduced in PR: https://github.com/jojojames/fussy/pull/36