### PR TITLE
Fix hotfuzz scoring

### DIFF
--- a/fussy.el
+++ b/fussy.el
@@ -141,7 +141,8 @@ candidates. Keep N at 0 or more for performance."
   '((flx-score . -100)
     (fussy-fuz-score . -100)
     (fussy-fuz-bin-score . -100)
-    (fussy-fzf-native-score . 0))
+    (fussy-fzf-native-score . 0)
+    (fussy-hotfuzz-score . 0))
   "Candidates with scores of N or less are filtered for a given
 `fussy-score-fn'.
 
@@ -1214,7 +1215,7 @@ highlighting."
   (when (fboundp 'hotfuzz--cost)
     ;; Looks like the score is flipped for `hotfuzz'.
     ;; See `hotfuzz-all-completions'.
-    (list (- (hotfuzz--cost query str)))))
+    (list (+ 10000 (- (hotfuzz--cost query str))))))
 
 (provide 'fussy)
 ;;; fussy.el ends here


### PR DESCRIPTION
From how I understand it, Hotfuzz scoring works in the following way:

Any score over 10000 is a missed match.
Any score under 0 is an exact match.
Any score inbetween is a partial match with lower scores being better.

As such, we want to reverse the scale by negating the result. But then partial matches will be between -10000 and 0, so we need to add 10000. We filter out any transformed score under 0 (over 10000 originally).